### PR TITLE
updates for Wiki on 06/05/2021

### DIFF
--- a/_docs/commands/commands.md
+++ b/_docs/commands/commands.md
@@ -666,15 +666,13 @@ worldport  | v      | Ports you to given map and coordination      | .worldport 
 
 ## .transport
 
-Subcommand | Access | Description                                 | Usage                                               
----------- | ------ | ------------------------------------------- | ----------------------------------------------------
-info       | m      |  Displays the current transport info        | .transport info                                     
-spawn      | m      | Spawns a transport in the current instance  | .transport spawn <entry:u32> <period:u32 time in ms>
-despawn    | m      | Despawns the transport you are currently on | .transport despawn                                  
-start      | m      | Force starts the current transport          | .transport start                                    
-stop       | m      | Force stops the current transport           | .transport stop                                     
-modperiod  | m      | Changes the period of the current transport | .transport modpersiod <period:i32 time in ms>       
-getperiod  | m      | Displays the current transport period in ms | .transport getperiod                                
+Subcommand | Access | Description                                               | Usage                                               
+---------- | ------ | --------------------------------------------------------- | ----------------------------------------------------
+info       | m      | Displays the current transport info                       | .transport info                                     
+spawn      | m      | Spawns transport with entry/period in current instance    | .transport spawn <entry:u32> <period:u32 time in ms>                        
+start      | m      | Force starts the current transport                        | .transport start                                    
+stop       | m      | Force stops the current transport                         | .transport stop                                     
+getperiod  | m      | Displays the current transport period in ms               | .transport getperiod                                
 
 ## .vehicle
 

--- a/_docs/packets/0_Packet_List.md
+++ b/_docs/packets/0_Packet_List.md
@@ -545,7 +545,7 @@ Opcode Name | Classic Status | TBC Status | WotLK Status | Cata Status | MoP Sta
 [MSG_GM_SUMMON](#msg_gm_summon) |  |  |  |  | 
 [MSG_GUILD_BANK_LOG_QUERY](#msg_guild_bank_log_query) | serialized |  | serialized | serialized | serialized
 [MSG_GUILD_BANK_MONEY_WITHDRAWN](#msg_guild_bank_money_withdrawn) | serialized | serialized | serialized |  | 
-[SMSG_ITEM_TIME_UPDATE](#smsg_item_time_update) | serialized | serialized | serialized | serialized | not used
+[SMSG_ITEM_TIME_UPDATE](#smsg_item_time_update) | serialized | serialized | serialized | serialized | serialized
 [SMSG_ITEM_ENCHANT_TIME_UPDATE](#smsg_item_enchant_time_update) | serialized | serialized | serialized | serialized | serialized
 [SMSG_AUTH_CHALLENGE](#smsg_auth_challenge) | serialized | serialized | serialized | serialized | serialized
 [CMSG_AUTH_SESSION](#cmsg_auth_session) |  |  |  |  | 
@@ -737,7 +737,7 @@ Opcode Name | Classic Status | TBC Status | WotLK Status | Cata Status | MoP Sta
 [SMSG_PVP_OPTIONS_ENABLED](#smsg_pvp_options_enabled) | not used | not used | not used | serialized | serialized
 [SMSG_AUCTION_REMOVED_NOTIFICATION](#smsg_auction_removed_notification) |  |  |  |  | 
 [SMSG_AURA_UPDATE](#smsg_aura_update) | not used | not used | serialized | serialized | serialized
-[SMSG_AURA_UPDATE_ALL](#smsg_aura_update_all) |  |  | serialized | serialized | 
+[SMSG_AURA_UPDATE_ALL](#smsg_aura_update_all) | not used | not used | serialized | serialized | serialized
 [CMSG_GROUP_RAID_CONVERT](#cmsg_group_raid_convert) |  |  |  |  | 
 [CMSG_GROUP_ASSISTANT_LEADER](#cmsg_group_assistant_leader) | serialized |  | serialized |  | 
 [CMSG_BUYBACK_ITEM](#cmsg_buyback_item) | serialized |  | serialized | serialized | serialized
@@ -1009,7 +1009,7 @@ Opcode Name | Classic Status | TBC Status | WotLK Status | Cata Status | MoP Sta
 [CMSG_MOVE_CHNG_TRANSPORT](#cmsg_move_chng_transport) |  |  |  |  | 
 [MSG_PARTY_ASSIGNMENT](#msg_party_assignment) | serialized |  | serialized |  | 
 [SMSG_OFFER_PETITION_ERROR](#smsg_offer_petition_error) |  |  |  |  | 
-[SMSG_TIME_SYNC_REQ](#smsg_time_sync_req) | serialized | serialized | serialized | serialized | 
+[SMSG_TIME_SYNC_REQ](#smsg_time_sync_req) | serialized | serialized | serialized | serialized | serialized
 [CMSG_TIME_SYNC_RESP](#cmsg_time_sync_resp) |  |  |  |  | 
 [CMSG_SEND_LOCAL_EVENT](#cmsg_send_local_event) |  |  |  |  | 
 [CMSG_SEND_GENERAL_TRIGGER](#cmsg_send_general_trigger) |  |  |  |  | 

--- a/_docs/packets/MSG_SET_DUNGEON_DIFFICULTY.md
+++ b/_docs/packets/MSG_SET_DUNGEON_DIFFICULTY.md
@@ -15,4 +15,4 @@ Classic    | 0x329      |
 TBC        |            | 
 WotLK      | 0x329      | 
 Cata       | 0x4925     | 
-MoP        | 0x4925     | 
+MoP        | 0x1283     | 

--- a/_docs/packets/MSG_SET_RAID_DIFFICULTY.md
+++ b/_docs/packets/MSG_SET_RAID_DIFFICULTY.md
@@ -15,4 +15,4 @@ Classic    | -          | not used
 TBC        | -          | not used
 WotLK      | 0x4EB      | 
 Cata       | 0x0614     | 
-MoP        | 0x0614     | 
+MoP        | 0x0591     | 

--- a/_docs/packets/SMSG_AURA_UPDATE_ALL.md
+++ b/_docs/packets/SMSG_AURA_UPDATE_ALL.md
@@ -11,8 +11,8 @@ position: 1062
 
 Version    | Hex        | Comment
 ---------- | ---------- | ---------- 
-Classic    |            | 
-TBC        |            | 
+Classic    | -          | not used
+TBC        | -          | not used
 WotLK      | 0x495      | 
 Cata       | 0x6916     | 
-MoP        |            | 
+MoP        | 0x0072     | 

--- a/_docs/packets/SMSG_CAST_FAILED.md
+++ b/_docs/packets/SMSG_CAST_FAILED.md
@@ -15,4 +15,4 @@ Classic    | 0x130      |
 TBC        | 0x130      | 
 WotLK      | 0x130      | 
 Cata       | 0x4D16     | 
-MoP        | 0x130      |
+MoP        | 0x143A     |

--- a/_docs/packets/SMSG_FEATURE_SYSTEM_STATUS.md
+++ b/_docs/packets/SMSG_FEATURE_SYSTEM_STATUS.md
@@ -15,4 +15,4 @@ Classic    | 0x3C8      |
 TBC        | 0x3C8      | 
 WotLK      | 0x3C9      | 
 Cata       | 0x3DB7     | 
-MoP        | 0x3DB7     | 
+MoP        | 0x16BB     | 

--- a/_docs/packets/SMSG_ITEM_TIME_UPDATE.md
+++ b/_docs/packets/SMSG_ITEM_TIME_UPDATE.md
@@ -15,4 +15,4 @@ Classic    | 0x1EA      |
 TBC        | 0x1EA      | 
 WotLK      | 0x1EA      | 
 Cata       | 0x2407     | 
-MoP        | 0          | not used
+MoP        | 0x18C1     | 

--- a/_docs/packets/SMSG_SET_FORCED_REACTIONS.md
+++ b/_docs/packets/SMSG_SET_FORCED_REACTIONS.md
@@ -15,4 +15,4 @@ Classic    | 0x2A5      |
 TBC        | 0x2A5      | 
 WotLK      | 0x2A5      | 
 Cata       | 0x4615     | 
-MoP        | 0x4615     | 
+MoP        | 0x068F     | 

--- a/_docs/packets/SMSG_SPELL_COOLDOWN.md
+++ b/_docs/packets/SMSG_SPELL_COOLDOWN.md
@@ -15,4 +15,4 @@ Classic    | 0x134      |
 TBC        | 0x134      | 
 WotLK      | 0x134      | 
 Cata       | 0x4B16     | 
-MoP        | 0x4B16     | 
+MoP        | 0x0452     | 

--- a/_docs/packets/SMSG_SPELL_FAILURE.md
+++ b/_docs/packets/SMSG_SPELL_FAILURE.md
@@ -15,4 +15,4 @@ Classic    | 0x133      |
 TBC        | 0x133      | 
 WotLK      | 0x133      | 
 Cata       | 0x0C34     | 
-MoP        | 0x0C34     | 
+MoP        | 0x04AF     | 

--- a/_docs/packets/SMSG_TIME_SYNC_REQ.md
+++ b/_docs/packets/SMSG_TIME_SYNC_REQ.md
@@ -15,4 +15,4 @@ Classic    | 0x390      |
 TBC        | 0x390      | 
 WotLK      | 0x390      | 
 Cata       | 0x3CA4     | 
-MoP        | 0x0000     | 
+MoP        | 0x1A8F     | 

--- a/_docs/packets/SMSG_UPDATE_INSTANCE_OWNERSHIP.md
+++ b/_docs/packets/SMSG_UPDATE_INSTANCE_OWNERSHIP.md
@@ -15,4 +15,4 @@ Classic    | 0x32B      |
 TBC        | 0x32B      | 
 WotLK      | 0x32B      | 
 Cata       | 0x4915     | 
-MoP        | 0x4915     | 
+MoP        | 0x10E0     | 

--- a/_docs/standards_sctipts/methods_lua/Unit_Methods.md
+++ b/_docs/standards_sctipts/methods_lua/Unit_Methods.md
@@ -535,5 +535,4 @@ GetTimeLeft()                                                                   
 
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------
 GetGameTime()                                                                                                                                                            | Deprecated. Use the global GetGameTime() instead.
-GetTarget()                                                                                                                                                              | Deprecated. Use [GetSelection()](/Wiki/docs/standards_sctipts/methods_lua/Unit_Methods/Lua_GetSelection) instead.
 SendPacketToInstance(packet)                                                                                                                                             | Deprecated. Use SendPacketToInstance(packet) instead.


### PR DESCRIPTION
Remove outdated function from LuaEngine (https://github.com/AscEmu/AscEmu/commit/282e255f923bd974f4a41af1d9bffebee64c4ced)
updating opcode data (mop)
updating commands (.transport)